### PR TITLE
Reset make party state for new runs

### DIFF
--- a/Party Function/Members/conditions/10-Make party.txt
+++ b/Party Function/Members/conditions/10-Make party.txt
@@ -1,7 +1,7 @@
 periodical
 1
 if int(self.attr1) == 2 and int(selfsubg.sincro) == 6:
-	print(f"[MEMBER] {self.name} making party")
-	time.sleep(self.randomize_delay(0.75,1.5))
-	self.make_party(1)
-	self.attr1 = 3
+        print(f"[MEMBER] {self.name} preparing subgroup party flow")
+        time.sleep(self.randomize_delay(0.75, 1.5))
+        if self.make_party(True):
+                self.attr1 = 3


### PR DESCRIPTION
## Summary
- detect when a subgroup make-party run should restart based on configuration, readiness, or completion
- clear invitation and acceptance tracking at the start of a new run so members resend invites in order

## Testing
- python -m py_compile ScriptCreator/player.py ScriptCreator/conditioncreator.py ScriptCreator/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d74df6c1d4832d940643a12ca7b978